### PR TITLE
feat: allow passing port to program by PORT=9001

### DIFF
--- a/main.js
+++ b/main.js
@@ -121,7 +121,7 @@ function createWindow() {
   if (dev && process.argv.indexOf("--noDevServer") === -1) {
     indexPath = url.format({
       protocol: 'http:',
-      host: 'localhost:8080',
+      host: `localhost:${process.env.PORT || 9000}`,
       pathname: 'index.html',
       slashes: true
     });

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -46,7 +46,7 @@ module.exports = {
   ],
   devtool: 'cheap-source-map',
   devServer: {
-    process.env.PORT || 9000,
+    port: process.env.PORT || 9000,
     contentBase: path.resolve(__dirname, 'dist'),
     stats: {
       colors: true,

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -46,6 +46,7 @@ module.exports = {
   ],
   devtool: 'cheap-source-map',
   devServer: {
+    process.env.PORT || 9000,
     contentBase: path.resolve(__dirname, 'dist'),
     stats: {
       colors: true,


### PR DESCRIPTION
changed two files and hardcoded the port to 9000 by default.
Using process.env allows one to change the desired port if collision occurs by using `PORT=9001 yarn start`